### PR TITLE
Feature: Save User Data to Cloud Firestore

### DIFF
--- a/lib/screens/auth.dart
+++ b/lib/screens/auth.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:chat_app/widget/user_image_picker.dart';
 import 'package:chat_app/utils/message_helper.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_storage/firebase_storage.dart';
 import 'package:flutter/material.dart';
@@ -21,6 +22,7 @@ class _AuthScreenState extends State<AuthScreen> {
   var _isLogin = true;
   var _enteredEmail = '';
   var _enteredPassword = '';
+  var _username = '';
   File? _selectedImage;
 
   var _isLoading = false; // Adicionar loading state
@@ -63,7 +65,16 @@ class _AuthScreenState extends State<AuthScreen> {
 
         await storageRef.putFile(_selectedImage!);
         final imageUrl = await storageRef.getDownloadURL();
-        print(imageUrl);
+
+        // Envio de dados para Cloud Firestore
+        await FirebaseFirestore.instance
+            .collection('users')
+            .doc(userCredentials.user!.uid)
+            .set({
+          'username': _username,
+          'email': _enteredEmail,
+          'image_url': imageUrl
+        });
       }
     } on FirebaseAuthException catch (authError) {
       String message = 'Authentication failed.';
@@ -140,6 +151,20 @@ class _AuthScreenState extends State<AuthScreen> {
                               },
                             ),
                           TextFormField(
+                            enableSuggestions: false,
+                            textInputAction: TextInputAction.next,
+                            decoration: const InputDecoration(
+                              labelText: 'Username',
+                            ),
+                            validator: (value) {
+                              if (value == null || value.isEmpty || value.trim().length <4) {
+                                return 'Please enter at least 4 characters.';
+                              }
+                              return null;
+                            },
+                            onSaved: (value) => _username = value!,
+                          ),
+                          TextFormField(
                             textInputAction: TextInputAction.next,
                             decoration: const InputDecoration(
                               labelText: 'Email Address',
@@ -155,10 +180,9 @@ class _AuthScreenState extends State<AuthScreen> {
                               }
                               return null;
                             },
-                            onSaved: (value) {
-                              _enteredEmail = value!;
-                            },
+                            onSaved: (value) =>_enteredEmail = value!
                           ),
+                          if (!_isLogin)
                           TextFormField(
                             decoration: const InputDecoration(
                               labelText: 'Password',
@@ -170,9 +194,7 @@ class _AuthScreenState extends State<AuthScreen> {
                               }
                               return null;
                             },
-                            onSaved: (value) {
-                              _enteredPassword = value!;
-                            },
+                            onSaved: (value) => _enteredPassword = value!
                           ),
                           const SizedBox(height: 12),
                           ElevatedButton(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -41,6 +41,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.2"
+  cloud_firestore:
+    dependency: "direct main"
+    description:
+      name: cloud_firestore
+      sha256: "39be8bf17e55d1211d8e2142ba1551bbcf30e272fe90adb36d54a9b1ae97bd30"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.6.11"
+  cloud_firestore_platform_interface:
+    dependency: transitive
+    description:
+      name: cloud_firestore_platform_interface
+      sha256: a8a1ce4f8da07225b8fe37ee3eeff3bde019e0607bab93329091f5491ee2f62f
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.6.11"
+  cloud_firestore_web:
+    dependency: transitive
+    description:
+      name: cloud_firestore_web
+      sha256: a3c0c5913860abfa0c9af68e245feb24d51ffebf07910780efc0d01ac463dc92
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.4.11"
   collection:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,7 @@ dependencies:
   firebase_core: ^3.15.1
   firebase_storage: ^12.4.9
   image_picker: ^1.1.2
+  cloud_firestore: ^5.6.11
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This pull request implements the functionality to save user information (such as username, email, and profile image URL) to a Cloud Firestore database upon successful user registration. This allows for persistent storage and retrieval of user profile data beyond just authentication.

**Key Features & Changes:**

*   **Cloud Firestore Integration:**
    *   Added the `cloud_firestore` dependency to the project to enable interaction with the Firestore database (`chore: add cloud_firestore dependency`).
*   **User Data Persistence:**
    *   Upon successful user signup (after authentication and potential image upload), relevant user data (e.g., username, email, and the download URL of their profile image from Firebase Storage) is now saved as a new document in a "users" collection in Cloud Firestore. The document ID typically corresponds to the user's UID from Firebase Authentication (`feat: Save user data to Firestore Database`).

**How to Test:**

1.  **New User Signup and Data Persistence:**
    *   Navigate to the signup/registration form.
    *   Complete all required fields, including selecting a profile image (if this is part of your signup flow prior to this PR's changes).
    *   Submit the signup form.
    *   **Verify:** Signup is successful.
    *   **Verify (Firebase Console):**
        *   Navigate to your Firebase project's **Cloud Firestore** section.
        *   Check for a "users" collection (or the name you've chosen).
        *   Inside this collection, verify that a new document has been created with an ID matching the new user's UID.
        *   Open the document and verify that it contains the correct user information, such as username, email, and the `image_url` (which should be the download URL from Firebase Storage if profile images are handled).